### PR TITLE
fix: 睡眠ログの時間表記を24時間制に変更 #10

### DIFF
--- a/front/react-app/src/Pages/SleepLogs.tsx
+++ b/front/react-app/src/Pages/SleepLogs.tsx
@@ -88,7 +88,7 @@ export const SleepLogs = (): JSX.Element => {
                       {log.sleepAt.format("MM/DD(dd)")}
                     </div>
                     <div className="w-1/2 tracking-wider">
-                      {log.sleepAt.format("hh:mm")} ~ {log.wakeAt.format("hh:mm")}
+                      {log.sleepAt.format("HH:mm")} ~ {log.wakeAt.format("HH:mm")}
                     </div>
                     <div className="w-1/4 tracking-wider">
                       { `(${log.sleepTime})` }


### PR DESCRIPTION
format内で12時間表記になっていたところを24時間表記に変更しました。